### PR TITLE
Added support for Mac OS X notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 /.settings
 /.classpath
+.idea/
+*.iml
+atlassian-ide-plugin.xml

--- a/README.md
+++ b/README.md
@@ -2,14 +2,23 @@
 
 Simple build extension for Maven 3.0.2 or newer which notifies the user when a build is complete.
 
-Currently supported on Linux only using `notify-send`. I've tested Gnome 3, KDE 4, Unity but other
-compliant implementations, for instance those provided by Cinnamon and Xfce should work just fine.
+Currently supported on Linux and Mac OS X 10.8 or higher.
+
+## How To ##
 
 To install the desktop notifier, simply drop it inside the `lib/ext` directory of your Maven installation.
 
+### Linux ###
+On Linux Maven Desktop Notifier uses `notify-send`. Tests were performed on  Gnome 3, KDE 4, Unity but other
+compliant implementations, for instance those provided by Cinnamon and Xfce should work just fine.
+
+### Mac OS X ###
+On Mac OS X 10.8 or higher, Maven Desktop Notifier uses `terminal-notifier`. Installation instructions for `terminal-notifier` can be found
+[here](https://github.com/alloy/terminal-notifier/).
+
 ## Screenshots
 
-### Gnome 
+### Gnome
 
 ![](https://raw.github.com/wiki/rombert/maven-desktop-notifier/images/maven-desktop-notifier-gnome.png)
 ![](https://raw.github.com/wiki/rombert/maven-desktop-notifier/images/maven-desktop-notifier-gnome-failure.png)
@@ -23,3 +32,8 @@ To install the desktop notifier, simply drop it inside the `lib/ext` directory o
 
 ![](https://raw.github.com/wiki/rombert/maven-desktop-notifier/images/maven-desktop-notifier-unity.png)
 ![](https://raw.github.com/wiki/rombert/maven-desktop-notifier/images/maven-desktop-notifier-unity-failure.png)
+
+### Mac OS X
+![](https://raw.github.com/wiki/rombert/maven-desktop-notifier/images/maven-desktop-notifier-macosx.png)
+![](https://raw.github.com/wiki/rombert/maven-desktop-notifier/images/maven-desktop-notifier-macosx-failure.png)
+![](https://raw.github.com/wiki/rombert/maven-desktop-notifier/images/maven-desktop-notifier-macosx-notification-centre.png)

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <!--
     Copyright 2013 Robert Munteanu
-    
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-    
+
     http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/ro/lmn/maven/mdn/NotifySendEventSpy.java
+++ b/src/main/java/ro/lmn/maven/mdn/NotifySendEventSpy.java
@@ -61,14 +61,47 @@ public class NotifySendEventSpy extends AbstractEventSpy {
 
     private void notifySend(String title, String details, String icon) throws IOException {
 
-        ProcessBuilder builder = new ProcessBuilder("/usr/bin/notify-send", title, details, "--icon=" + icon,
-                "--app-name=Maven", "--hint=int:transient:1");
-        Process process = builder.start();
-        try {
-            process.waitFor();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt(); // restore interrupted status
-            return;
+        ProcessBuilder builder = null;
+        OSName os = OSName.getConstantForValue(System.getProperty("os.name"));
+        if (os != null) {
+            switch (os) {
+                case LINUX:
+                    builder = new ProcessBuilder("/usr/bin/notify-send", title, details, "--icon=" + icon, "--app-name=Maven",
+                            "--hint=int:transient:1");
+                    break;
+                case MAC:
+                    builder = new ProcessBuilder("terminal-notifier", "-title", title, "-message", details);
+            }
+
+            Process process = builder.start();
+            try {
+                process.waitFor();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt(); // restore interrupted status
+                return;
+            }
         }
+    }
+
+    private enum OSName {
+
+        LINUX("Linux"),
+        MAC("Mac OS X");
+
+        private String osName;
+
+        private OSName(String osName) {
+            this.osName = osName;
+        }
+
+        public static OSName getConstantForValue(String value) {
+            for (OSName constant : OSName.values()) {
+                if (constant.osName.equals(value)) {
+                    return constant;
+                }
+            }
+            return null;
+        }
+
     }
 }


### PR DESCRIPTION
Added support for Mac OS X notifications through `terminal-notifier`. More details can be found in the `README.md` file.
