### PR TITLE
Mac: doesn't find terminal-notifier if in different path

### DIFF
--- a/src/main/java/ro/lmn/maven/dmn/impl/AbstractNotifier.java
+++ b/src/main/java/ro/lmn/maven/dmn/impl/AbstractNotifier.java
@@ -24,6 +24,8 @@ import ro.lmn.maven.dmn.api.Notifier;
  */
 public abstract class AbstractNotifier implements Notifier {
 
+    protected ExecutableLocator locator = new ExecutableLocator();
+
     protected static String getOSName() {
         return System.getProperty("os.name");
     }

--- a/src/main/java/ro/lmn/maven/dmn/impl/ExecutableLocator.java
+++ b/src/main/java/ro/lmn/maven/dmn/impl/ExecutableLocator.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ro.lmn.maven.dmn.impl;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * Locates executables on a search path, including support for
+ * the OS PATH environment variable.
+ */
+public class ExecutableLocator {
+
+    /** Use this to reference the OS PATH environment variable in the search path */
+    public static final String PATH_ENV = "PATH";
+
+    private static final boolean IS_WINDOWS = isWindows();
+
+    private List<String> searchPath;
+    private File last;
+
+    /**
+     * Searches on the paths in the OS PATH environment variable.
+     */
+    public ExecutableLocator() {
+        setSearchPath(new String[] { PATH_ENV });
+    }
+
+    /**
+     * Searches on the custom defined path list. Use {@link #PATH_ENV} to refer to
+     * the OS PATH environment variable in the list (it will be expanded).
+     */
+    public ExecutableLocator(String[] searchPath) {
+        setSearchPath(searchPath);
+    }
+
+    public void setSearchPath(String[] sp) {
+        searchPath = new ArrayList<String>();
+        for (String path : sp) {
+            if (PATH_ENV.equals(path)) {
+                Collections.addAll(searchPath, getPathEnv());
+            } else {
+                searchPath.add(path);
+            }
+        }
+        //System.out.printf("Search path: %s", StringUtils.join(searchPath.toArray(), ", "));
+    }
+
+    /** Clears the search path. Use to {@link #add(String) add paths} step by step. */
+    public void clear() {
+        searchPath.clear();
+    }
+
+    /** Adds a path at the end of the search path list. */
+    public void add(String path) {
+        searchPath.add(path);
+    }
+
+    /** Checks whether a given executable command is available and executable on the search path. */
+    public boolean isAvailable(String cmd) {
+        return getPath(cmd) != null;
+    }
+
+    /**
+     * Returns the full absolute path for the given executable command or null
+     */
+    public String getPath(String cmd) {
+        if (IS_WINDOWS && cmd != null && !cmd.endsWith(".exe")) {
+            cmd = cmd + ".exe";
+        }
+        // quick check for last used executable
+        if (last != null && last.getName().equals(cmd) && last.exists()) {
+            //System.out.printf("Found executable '%s' (cached): %s", cmd, last.getAbsolutePath());
+            return last.getAbsolutePath();
+        }
+
+        if (searchPath != null) {
+            for (String path : searchPath) {
+                File file = new File(path, cmd);
+                if (file.exists() && file.canExecute()) {
+                    last = file;
+                    //System.out.printf("Found executable '%s': %s", cmd, file.getAbsolutePath());
+                    return file.getAbsolutePath();
+                }
+            }
+        }
+
+        //System.out.printf("Could not find executable '%s'!", cmd);
+
+        // not found
+        return null;
+    }
+
+    private static String[] getPathEnv() {
+        String path = System.getenv("PATH");
+        if (path == null) {
+            path = System.getenv("Path");
+        }
+
+        if (path == null) {
+            return new String[0];
+        }
+
+        return StringUtils.split(path, File.pathSeparatorChar + "");
+    }
+
+    private static boolean isWindows() {
+        return System.getProperty("os.name").startsWith("Windows");
+    }
+}

--- a/src/main/java/ro/lmn/maven/dmn/impl/MacOSXNotifier.java
+++ b/src/main/java/ro/lmn/maven/dmn/impl/MacOSXNotifier.java
@@ -15,7 +15,6 @@
  */
 package ro.lmn.maven.dmn.impl;
 
-import java.io.File;
 import java.io.IOException;
 
 import ro.lmn.maven.dmn.api.NotificationType;
@@ -25,11 +24,11 @@ import ro.lmn.maven.dmn.api.NotificationType;
  */
 public class MacOSXNotifier extends AbstractNotifier {
 
-    private static final File terminalNotifier = new File("/usr/local/bin/terminal-notifier");
+    public static final String TERMINAL_NOTIFIER = "terminal-notifier";
 
     @Override
     public void notify(String title, String details, NotificationType notificationType) throws IOException {
-        ProcessBuilder builder = new ProcessBuilder(terminalNotifier.getAbsolutePath(), "-title", title, "-message", details);
+        ProcessBuilder builder = new ProcessBuilder(locator.getPath(TERMINAL_NOTIFIER), "-title", title, "-message", details);
         executeProcess(builder);
     }
 
@@ -38,6 +37,6 @@ public class MacOSXNotifier extends AbstractNotifier {
         if (OSType.MAC != OSType.getConstantForValue(getOSName())) {
             return false;
         }
-        return terminalNotifier.exists() && terminalNotifier.canExecute();
+        return locator.isAvailable(TERMINAL_NOTIFIER);
     }
 }


### PR DESCRIPTION
**Problem**

I installed the terminal-notifier using ruby gems which puts it at

```
/usr/bin/terminal-notifier
```

while the current implementation expects it at

```
/usr/local/bin/terminal-notifier
```

I suggest it to use the OS `$PATH` env variable to find executables.

**Solution in Pull Request**

To solve it, added ExecutableLocator that searches the OS
PATH environment variable (by default) for executables.
Only used for the MacOSXNotifier so far, but other notifiers
could use it as well, it has support for windows exe's as well.

Can also be configured with explicit search paths (i.e. no PATH env):

```
// $PATH by default
ExecutableLocator locator = new ExecutableLocator();
// finding command
if (locator.isAvailable("terminal-notifier")) {
    String absPath = locator.getPath("terminal-notifier");
    Runtime.exec(absPath);
}

// mixed search path referencing $PATH
locator = new ExecutableLocator(new String[] { "/some/custom/bin", ExecutableLocator.PATH_ENV });

// alternative way of adding search path step by step
locator.clear();
locator.add("/some/custom/bin");
locator.add(ExecutableLocator.PATH_ENV);
```
