### PR TITLE
fix #14: Notifications are not dispatched on Mac OS X 10.9 with terminal-notifier installed

### DIFF
--- a/src/main/java/ro/lmn/maven/dmn/impl/MacOSXNotifier.java
+++ b/src/main/java/ro/lmn/maven/dmn/impl/MacOSXNotifier.java
@@ -28,7 +28,8 @@ public class MacOSXNotifier extends AbstractNotifier {
 
     @Override
     public void notify(String title, String details, NotificationType notificationType) throws IOException {
-        ProcessBuilder builder = new ProcessBuilder(locator.getPath(TERMINAL_NOTIFIER), "-title", title, "-message", details);
+        ProcessBuilder builder = new ProcessBuilder(locator.getPath(TERMINAL_NOTIFIER), "-title", title, "-message", details, "-sender",
+                "com.apple.Terminal");
         executeProcess(builder);
     }
 


### PR DESCRIPTION
Added sender flag for terminal-notifier notifications.
