### PR TITLE
Introduce new MacOSX notifier that relies on osascript instead of terminal-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ On Linux Maven Desktop Notifier uses `notify-send` and, where available, `kdialo
 but other compliant implementations, for instance those provided by Cinnamon and Xfce, should work just fine.
 
 ### Mac OS X ###
-On Mac OS X 10.8 or higher, Maven Desktop Notifier uses `terminal-notifier`. Installation instructions for `terminal-notifier` can be found
+Maven Desktop Notifier uses the Notification Center.
+
+On Mac OS X 10.9 or higher, Maven Desktop Notifier uses `osascript` unless `terminal-notifier` has been installed.
+On Mac OS X 10.8, Maven Desktop Notifier uses `terminal-notifier`. Installation instructions for `terminal-notifier` can be found
 [here](https://github.com/alloy/terminal-notifier/).
 
 ### Windows ###

--- a/src/main/java/ro/lmn/maven/dmn/NotifierFactory.java
+++ b/src/main/java/ro/lmn/maven/dmn/NotifierFactory.java
@@ -23,6 +23,7 @@ import java.util.List;
 import ro.lmn.maven.dmn.api.Notifier;
 import ro.lmn.maven.dmn.impl.LinuxNotifier;
 import ro.lmn.maven.dmn.impl.MacOSXNotifier;
+import ro.lmn.maven.dmn.impl.MacOSXOsaNotifier;
 import ro.lmn.maven.dmn.impl.SystemTrayNotifier;
 import ro.lmn.maven.dmn.impl.WindowsNotifier;
 
@@ -32,6 +33,7 @@ public class NotifierFactory {
     {
         notifiers.add(new LinuxNotifier());
         notifiers.add(new MacOSXNotifier());
+        notifiers.add(new MacOSXOsaNotifier());
         notifiers.add(new WindowsNotifier());
         notifiers.add(new SystemTrayNotifier());
         

--- a/src/main/java/ro/lmn/maven/dmn/impl/MacOSXOsaNotifier.java
+++ b/src/main/java/ro/lmn/maven/dmn/impl/MacOSXOsaNotifier.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013 Radu Cotescu
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ro.lmn.maven.dmn.impl;
+
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import ro.lmn.maven.dmn.api.NotificationType;
+
+import java.io.IOException;
+
+/**
+ * NotifierFactory for Mac OS X based on OSA <code><a href="https://developer.apple.com/library/content/documentation/AppleScript/Conceptual/AppleScriptLangGuide/reference/ASLR_cmds.html#//apple_ref/doc/uid/TP40000983-CH216-SW224>display notification</a></code>.
+ * Support has been introduced with <code><a href="https://developer.apple.com/library/content/releasenotes/AppleScript/RN-AppleScript/RN-10_9/RN-10_9.html">Mac OS X 10.9</a></code>.
+ */
+public class MacOSXOsaNotifier extends AbstractNotifier {
+
+    public static final String OSASCRIPT = "/usr/bin/osascript";
+
+    @Override
+    public void notify(String title, String details, NotificationType notificationType) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(OSASCRIPT, "-e", "display notification \"" + details + "\" with title \"" + title + "\"");
+        executeProcess(builder);
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return OSType.MAC == OSType.getDetected() && osaScriptHasDisplayNotification();
+    }
+
+    private static boolean osaScriptHasDisplayNotification() {
+        return new ComparableVersion(System.getProperty("os.version")).compareTo(new ComparableVersion("10.9")) >= 0;
+    }
+}

--- a/src/main/java/ro/lmn/maven/dmn/impl/MacOSXOsaNotifier.java
+++ b/src/main/java/ro/lmn/maven/dmn/impl/MacOSXOsaNotifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Radu Cotescu
+ * Copyright 2017 Denis N. Antonioli
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This new notifier is used as a fall-back on 10.9 and newer